### PR TITLE
update start example agp and Java version dependency

### DIFF
--- a/xr-fundamentals/start/app/build.gradle.kts
+++ b/xr-fundamentals/start/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
         jvmTarget = "11"

--- a/xr-fundamentals/start/gradle/libs.versions.toml
+++ b/xr-fundamentals/start/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0-alpha02"
+agp = "8.9.0-rc01"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"

--- a/xr-fundamentals/start/gradle/wrapper/gradle-wrapper.properties
+++ b/xr-fundamentals/start/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Nov 21 11:45:08 EST 2024
+#Tue Feb 11 20:20:36 GMT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip


### PR DESCRIPTION
Update Java version from 11 and 17 and agp from 8.10.0-alpha02 to 8.9.0-rc01 to meet the minimal requirements