### PR TITLE
Update to June release of Jetpack XR libraries

### DIFF
--- a/xr-fundamentals/part1/app/src/main/java/com/example/android/xrfundamentals/XRFundamentalsApp.kt
+++ b/xr-fundamentals/part1/app/src/main/java/com/example/android/xrfundamentals/XRFundamentalsApp.kt
@@ -33,8 +33,8 @@ import androidx.xr.compose.subspace.SpatialCurvedRow
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.height
-import androidx.xr.compose.subspace.layout.movable
-import androidx.xr.compose.subspace.layout.resizable
+import androidx.xr.compose.subspace.layout.transformingMovable
+import androidx.xr.compose.subspace.layout.transformingResizable
 import androidx.xr.compose.subspace.layout.width
 import com.example.android.xrfundamentals.ui.component.PrimaryCard
 import com.example.android.xrfundamentals.ui.component.SecondaryCardList
@@ -109,8 +109,8 @@ fun XRFundamentalsApp(
                 modifier = SubspaceModifier
                     .width(340.dp)
                     .height(800.dp)
-                    .movable()
-                    .resizable(),
+                    .transformingResizable()
+                    .transformingMovable(),
             ) {
                 Surface {
                     SecondaryCardList(

--- a/xr-fundamentals/part1/gradle/libs.versions.toml
+++ b/xr-fundamentals/part1/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 composeBom = "2026.05.00"
 composeMaterialAdaptive = "1.2.0"
-xrCompose = "1.0.0-alpha13"
+xrCompose = "1.0.0-alpha15"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/xr-fundamentals/part2/app/src/main/java/com/example/android/xrfundamentals/XRFundamentalsApp.kt
+++ b/xr-fundamentals/part2/app/src/main/java/com/example/android/xrfundamentals/XRFundamentalsApp.kt
@@ -42,6 +42,8 @@ import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.height
 import androidx.xr.compose.subspace.layout.movable
 import androidx.xr.compose.subspace.layout.resizable
+import androidx.xr.compose.subspace.layout.transformingMovable
+import androidx.xr.compose.subspace.layout.transformingResizable
 import androidx.xr.compose.subspace.layout.width
 import androidx.xr.scenecore.scene
 import com.example.android.xrfundamentals.environment.ENVIRONMENT_OPTIONS
@@ -147,8 +149,8 @@ fun XRFundamentalsApp(
                 modifier = SubspaceModifier
                     .width(340.dp)
                     .height(800.dp)
-                    .movable()
-                    .resizable(),
+                    .transformingMovable()
+                    .transformingResizable(),
             ) {
                 Surface {
                     SecondaryCardList(

--- a/xr-fundamentals/part2/app/src/main/java/com/example/android/xrfundamentals/XRFundamentalsApp.kt
+++ b/xr-fundamentals/part2/app/src/main/java/com/example/android/xrfundamentals/XRFundamentalsApp.kt
@@ -40,8 +40,6 @@ import androidx.xr.compose.subspace.SpatialCurvedRow
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.height
-import androidx.xr.compose.subspace.layout.movable
-import androidx.xr.compose.subspace.layout.resizable
 import androidx.xr.compose.subspace.layout.transformingMovable
 import androidx.xr.compose.subspace.layout.transformingResizable
 import androidx.xr.compose.subspace.layout.width

--- a/xr-fundamentals/part2/app/src/main/java/com/example/android/xrfundamentals/environment/EnvironmentOption.kt
+++ b/xr-fundamentals/part2/app/src/main/java/com/example/android/xrfundamentals/environment/EnvironmentOption.kt
@@ -17,8 +17,8 @@
 package com.example.android.xrfundamentals.environment
 
 import androidx.xr.runtime.Session
-import androidx.xr.scenecore.ExrImage
 import androidx.xr.scenecore.GltfModel
+import androidx.xr.scenecore.ImageBasedLightingAsset
 import androidx.xr.scenecore.SpatialEnvironment.SpatialEnvironmentPreference
 import kotlin.io.path.Path
 
@@ -28,7 +28,7 @@ data class EnvironmentOption(val name: String, val skyboxPath: String?, val geom
             return null
         } else {
             val skybox = skyboxPath?.let {
-                ExrImage.createFromZip(session, Path(it))
+                ImageBasedLightingAsset.createFromZip(session, Path(it))
             }
 
             val geometry = geometryPath?.let {

--- a/xr-fundamentals/part2/gradle/libs.versions.toml
+++ b/xr-fundamentals/part2/gradle/libs.versions.toml
@@ -9,8 +9,8 @@ lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 composeBom = "2026.05.00"
 composeMaterialAdaptive = "1.2.0"
-xrCompose = "1.0.0-alpha13"
-xrSceneCore = "1.0.0-alpha14"
+xrCompose = "1.0.0-alpha15"
+xrSceneCore = "1.0.0-alpha16"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
This PR updates the xr-codelabs repo to the June release of the Jetpack XR libraries:

* `ExrImage` is now [`ImageBasedLightingAsset`](https://developer.android.com//reference/kotlin/androidx/xr/scenecore/ImageBasedLightingAsset)
* `movable` and `resizable` were renamed to `transformingMovable` and `transformingResizable`